### PR TITLE
[CMPT-2396] Pin major version in sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,3 +19,4 @@ jobs:
         github_repository: "${GITHUB_REPOSITORY}"
         github_token: ${{ secrets.WORKFLOW_TOKEN }}
         upstream_repo: kubernetes-sigs/azuredisk-csi-driver
+        major_version: "1"


### PR DESCRIPTION
Avoids bumping the major version when rebasing datadog branch and producing new tag