### PR TITLE
[NODES-281] Delay Volume attachment when migrating disk type

### DIFF
--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -478,6 +478,23 @@ func (c *ManagedDiskController) ModifyDisk(ctx context.Context, options *Managed
 	}
 
 	if model.SKU != nil || model.Properties != nil {
+		if result.Tags == nil {
+			result.Tags = make(map[string]*string)
+		}
+		SKUTag := ptr.Deref(result.Tags[azureconsts.SkuNameField], "")
+		if model.SKU != nil && *model.SKU != *result.SKU && *model.SKU.Name == armcompute.DiskStorageAccountTypesPremiumV2LRS && SKUTag != string(*model.SKU.Name) {
+			targetSKUName := string(*model.SKU.Name)
+			sourceSKUName := string(*result.SKU.Name)
+			klog.V(1).Infof("azureDisk - modifying disk(%s) from %s to %s can't be performed online, tagging disk for offline conversion", diskName, sourceSKUName, targetSKUName)
+			model.Tags = result.Tags
+			model.Tags[azureconsts.SkuNameField] = &targetSKUName
+			model.SKU = result.SKU
+			if _, err := diskClient.Patch(ctx, rg, diskName, model); err != nil {
+				return err
+			}
+			// Force modification to be retried once the disk is detached
+			return fmt.Errorf("azureDisk - modifying disk(%s) from %s to %s can't be performed online, tagged disk for offline conversion", diskName, sourceSKUName, targetSKUName)
+		}
 		if _, err := diskClient.Patch(ctx, rg, diskName, model); err != nil {
 			return err
 		}

--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -482,7 +483,7 @@ func (c *ManagedDiskController) ModifyDisk(ctx context.Context, options *Managed
 			result.Tags = make(map[string]*string)
 		}
 		SKUTag := ptr.Deref(result.Tags[azureconsts.SkuNameField], "")
-		if model.SKU != nil && *model.SKU != *result.SKU && *model.SKU.Name == armcompute.DiskStorageAccountTypesPremiumV2LRS && SKUTag != string(*model.SKU.Name) {
+		if model.SKU != nil && !reflect.DeepEqual(*model.SKU, *result.SKU) && *model.SKU.Name == armcompute.DiskStorageAccountTypesPremiumV2LRS && SKUTag != string(*model.SKU.Name) {
 			targetSKUName := string(*model.SKU.Name)
 			sourceSKUName := string(*result.SKU.Name)
 			klog.V(1).Infof("azureDisk - modifying disk(%s) from %s to %s can't be performed online, tagging disk for offline conversion", diskName, sourceSKUName, targetSKUName)

--- a/pkg/azuredisk/azure_managedDiskController_test.go
+++ b/pkg/azuredisk/azure_managedDiskController_test.go
@@ -784,6 +784,14 @@ func TestModifyDisk(t *testing.T) {
 			expectedErr:        true,
 			expectedErrMsg:     fmt.Errorf("Patch Disk failed"),
 		},
+		{
+			desc:               "we should tag the disk for premium v2 conversion",
+			diskName:           diskName,
+			storageAccountType: armcompute.DiskStorageAccountTypesPremiumV2LRS,
+			existedDisk:        &armcompute.Disk{Name: ptr.To(diskName), SKU: &armcompute.DiskSKU{Name: &storageAccountTypePremiumLRS}, Properties: &armcompute.DiskProperties{}},
+			expectedErr:        true,
+			expectedErrMsg:     fmt.Errorf("azureDisk - modifying disk(disk1) from Premium_LRS to PremiumV2_LRS can't be performed online, tagged disk for offline conversion"),
+		},
 	}
 
 	for i, test := range testCases {

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -488,6 +488,10 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 		}
 	}
 
+	if err = d.waitForDiskConversion(disk, diskURI); err != nil {
+		return nil, err
+	}
+
 	nodeID := req.GetNodeId()
 	if len(nodeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Node ID not provided")
@@ -1288,4 +1292,30 @@ func (d *Driver) GetSourceDiskSize(ctx context.Context, subsID, resourceGroup, d
 		return nil, result, status.Error(codes.Internal, fmt.Sprintf("DiskSizeGB for disk (%s) in resourcegroup (%s) is nil", diskName, resourceGroup))
 	}
 	return (*result.Properties).DiskSizeGB, result, nil
+}
+
+// Delay attachment when changing disk SKU, this returns an error if the SKU change is in progress
+func (d *Driver) waitForDiskConversion(disk *armcompute.Disk, diskURI string) error {
+	// no tag indicating a SKU change request
+	tags := disk.Tags
+	if tags == nil {
+		return nil
+	}
+	skuName := ptr.Deref(tags[consts.SkuNameField], "")
+	if skuName == "" {
+		return nil
+	}
+
+	state := ptr.Deref(disk.Properties.ProvisioningState, "")
+	completion := ptr.Deref(disk.Properties.CompletionPercent, 0)
+
+	if armcompute.DiskStorageAccountTypes(skuName) != *disk.SKU.Name {
+		klog.V(1).Infof("Disk %s SKU change from %s to %s in progress: %s (%.2f%%).",
+			diskURI, *disk.SKU.Name, skuName, state, completion)
+		return status.Errorf(codes.Unavailable, "Disk %s SKU change from %s to %s in progress: %s (%.2f%%%%)",
+			diskURI, *disk.SKU.Name, skuName, state, completion)
+	}
+
+	klog.V(1).Infof("Disk %s conversion to %s initiated. Proceeding with attachment.", diskURI, *disk.SKU.Name)
+	return nil
 }

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -2902,6 +2902,89 @@ func TestGetSourceDiskSize(t *testing.T) {
 	}
 }
 
+func TestWaitForDiskConversion(t *testing.T) {
+	testCases := []struct {
+		name                        string
+		diskProperties              *armcompute.DiskProperties
+		diskTags                    map[string]*string
+		diskSKU                     *armcompute.DiskSKU
+		expectError                 bool
+		expectedErrorContainsString string
+	}{
+		{
+			name: "No SKU change in progress",
+			diskProperties: &armcompute.DiskProperties{
+				ProvisioningState: ptr.To("Succeeded"),
+				CompletionPercent: ptr.To(float32(100)),
+			},
+			diskTags: map[string]*string{},
+			diskSKU: &armcompute.DiskSKU{
+				Name: ptr.To(armcompute.DiskStorageAccountTypesPremiumLRS),
+			},
+			expectError: false,
+		},
+		{
+			name: "SKU change in progress",
+			diskProperties: &armcompute.DiskProperties{
+				ProvisioningState: ptr.To("Updating"),
+				CompletionPercent: ptr.To(float32(50)),
+			},
+			diskTags: map[string]*string{
+				consts.SkuNameField: ptr.To(string(armcompute.DiskStorageAccountTypesPremiumV2LRS)),
+			},
+			diskSKU: &armcompute.DiskSKU{
+				Name: ptr.To(armcompute.DiskStorageAccountTypesPremiumLRS),
+			},
+			expectError:                 true,
+			expectedErrorContainsString: "SKU change from Premium_LRS to PremiumV2_LRS in progress",
+		},
+		{
+			name: "SKU changed",
+			diskProperties: &armcompute.DiskProperties{
+				ProvisioningState: ptr.To("Succeeded"),
+				CompletionPercent: ptr.To(float32(50)),
+			},
+			diskTags: map[string]*string{
+				consts.SkuNameField: ptr.To(string(armcompute.DiskStorageAccountTypesPremiumV2LRS)),
+			},
+			diskSKU: &armcompute.DiskSKU{
+				Name: ptr.To(armcompute.DiskStorageAccountTypesPremiumV2LRS),
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cntl := gomock.NewController(t)
+			defer cntl.Finish()
+			d := getFakeDriverWithKubeClient(cntl)
+
+			disk := &armcompute.Disk{
+				Properties: tc.diskProperties,
+				SKU:        tc.diskSKU,
+				Tags:       tc.diskTags,
+			}
+			diskClient := mock_diskclient.NewMockInterface(cntl)
+			d.getClientFactory().(*mock_azclient.MockClientFactory).EXPECT().GetDiskClientForSub(gomock.Any()).Return(diskClient, nil).AnyTimes()
+			diskClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(disk, nil).AnyTimes()
+
+			err := d.waitForDiskConversion(disk, "test-disk-uri")
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if tc.expectedErrorContainsString != "" && !strings.Contains(err.Error(), tc.expectedErrorContainsString) {
+					t.Errorf("Error message doesn't contain expected string.\nExpected: %s\nGot: %s",
+						tc.expectedErrorContainsString, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
 func getFakeDriverWithKubeClient(ctrl *gomock.Controller) FakeDriver {
 	d, _ := NewFakeDriver(ctrl)
 

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -2969,7 +2969,7 @@ func TestWaitForDiskConversion(t *testing.T) {
 			d.getClientFactory().(*mock_azclient.MockClientFactory).EXPECT().GetDiskClientForSub(gomock.Any()).Return(diskClient, nil).AnyTimes()
 			diskClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(disk, nil).AnyTimes()
 
-			err := d.waitForDiskConversion(disk, "test-disk-uri")
+			err := d.waitForSKUChange(disk, "test-disk-uri")
 
 			if tc.expectError {
 				if err == nil {

--- a/pkg/azuredisk/fake_azuredisk.go
+++ b/pkg/azuredisk/fake_azuredisk.go
@@ -96,7 +96,7 @@ type FakeDriver interface {
 	setThrottlingCache(key string, value string)
 	getUsedLunsFromVolumeAttachments(context.Context, string) ([]int, error)
 	getUsedLunsFromNode(context.Context, types.NodeName) ([]int, error)
-	waitForDiskConversion(disk *armcompute.Disk, s string) error
+	waitForSKUChange(disk *armcompute.Disk, s string) error
 }
 
 type fakeDriverV1 struct {

--- a/pkg/azuredisk/fake_azuredisk.go
+++ b/pkg/azuredisk/fake_azuredisk.go
@@ -96,6 +96,7 @@ type FakeDriver interface {
 	setThrottlingCache(key string, value string)
 	getUsedLunsFromVolumeAttachments(context.Context, string) ([]int, error)
 	getUsedLunsFromNode(context.Context, types.NodeName) ([]int, error)
+	waitForDiskConversion(disk *armcompute.Disk, s string) error
 }
 
 type fakeDriverV1 struct {


### PR DESCRIPTION
This PR adds logic to delay volume attachment when converting to PremiumSSD v2 as we need the volume to be detached from the host for the conversion to start. Since we don't have access to kube client in that context, we're simply adding the target sku as a tag on the disk and we check if the tag and volume type match before attaching.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
