### PR TITLE
Merge pull request #3543 from gnufied/fix-incorrect-node-attached-wait-detached

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 
@@ -373,7 +374,7 @@ func (c *controllerCommon) DetachDisk(ctx context.Context, diskName, diskURI str
 			// if host doesn't exist, no need to detach
 			klog.Warningf("azureDisk - failed to get azure instance id(%s), DetachDisk(%s) will assume disk is already detached",
 				nodeName, diskURI)
-			return c.waitForDiskManagedByTobeRemoved(ctx, diskURI)
+			return c.waitForDiskManagedByTobeRemoved(ctx, diskURI, nodeName)
 		}
 		klog.Warningf("failed to get azure instance id (%v)", err)
 		return fmt.Errorf("failed to get azure instance id for node %q: %w", nodeName, err)
@@ -450,7 +451,7 @@ func (c *controllerCommon) DetachDisk(ctx context.Context, diskName, diskURI str
 			// if host doesn't exist, no need to detach
 			klog.Warningf("azureDisk - got InstanceNotFoundError(%v), DetachDisk(%s) will assume disk is already detached",
 				err, diskURI)
-			return c.waitForDiskManagedByTobeRemoved(ctx, diskURI)
+			return c.waitForDiskManagedByTobeRemoved(ctx, diskURI, nodeName)
 		}
 
 		// if operation is preempted by a force operation on VM, check if the disk got detached before returning error
@@ -477,7 +478,7 @@ func (c *controllerCommon) DetachDisk(ctx context.Context, diskName, diskURI str
 		return err
 	}
 
-	err = c.waitForDiskManagedByTobeRemoved(ctx, diskURI)
+	err = c.waitForDiskManagedByTobeRemoved(ctx, diskURI, nodeName)
 	if err != nil {
 		klog.Errorf("azureDisk - waitForDiskManagedByTobeRemoved(%s) failed, err: %v", diskURI, err)
 		return err
@@ -750,7 +751,7 @@ func (c *controllerCommon) isMaxDataDiskCountExceeded(ctx context.Context, nodeN
 // For cases where an instance is deleted, we assume the disk is detached, but it actually
 // takes a while for disk property to be updated. We do not want to presume such disks to be detached
 // without waiting for disk to be actually detached.
-func (c *controllerCommon) waitForDiskManagedByTobeRemoved(ctx context.Context, diskURI string) error {
+func (c *controllerCommon) waitForDiskManagedByTobeRemoved(ctx context.Context, diskURI string, nodeName types.NodeName) error {
 	subsID, resourceGroup, diskName, err := azureutils.GetInfoFromURI(diskURI)
 	if err != nil {
 		return err
@@ -768,6 +769,19 @@ func (c *controllerCommon) waitForDiskManagedByTobeRemoved(ctx context.Context, 
 		}
 
 		if disk.ManagedBy == nil {
+			return true, nil
+		}
+		attachedNode, err := c.cloud.VMSet.GetNodeNameByProviderID(ctx, *disk.ManagedBy)
+		if err != nil {
+			if errors.Is(err, cloudprovider.InstanceNotFound) || isInstanceNotFoundError(err) {
+				klog.V(2).Infof("disk %s is still marked as attached to %s, but instance is not found; waiting for ManagedBy to be cleared", diskURI, *disk.ManagedBy)
+				return false, nil
+			}
+			return false, fmt.Errorf("error resolving node name from providerID %s: %w", *disk.ManagedBy, err)
+		}
+
+		if !strings.EqualFold(string(attachedNode), string(nodeName)) {
+			klog.Warningf("expected to be detached from node %s, but found attached to %s, assuming as detached from original node", nodeName, attachedNode)
 			return true, nil
 		}
 
@@ -821,6 +835,14 @@ func getValidCreationData(subscriptionID, resourceGroup string, options *Managed
 }
 
 func isInstanceNotFoundError(err error) bool {
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) {
+		// Azure SDK "not found" shape.
+		if responseErr.StatusCode == 404 {
+			return true
+		}
+	}
+
 	errMsg := strings.ToLower(err.Error())
 	if strings.Contains(errMsg, strings.ToLower(consts.VmssVMNotActiveErrorMessage)) {
 		return true

--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -501,26 +501,54 @@ func TestCommonDetachDiskInstanceNotFoundWaitForDiskManagedByRemoved(t *testing.
 
 	managedBy := testManagedByValue
 	testCases := []struct {
-		desc        string
-		managedBy   *string
-		getErr      error
-		expectedErr bool
+		desc               string
+		nodeName           types.NodeName
+		managedBy          *string
+		attachedNodeName   types.NodeName
+		getNodeNameByIDErr error
+		getErr             error
+		expectedErr        bool
 	}{
 		{
 			desc:        "no error when ManagedBy cleared",
+			nodeName:    "vm1",
 			managedBy:   nil,
 			expectedErr: false,
 		},
 		{
 			desc:        "error when disk get fails",
+			nodeName:    "vm1",
 			managedBy:   nil,
 			getErr:      errors.New("get disk error"),
 			expectedErr: true,
 		},
 		{
-			desc:        "error when ManagedBy remains set",
-			managedBy:   &managedBy,
-			expectedErr: true,
+			desc:             "error when ManagedBy remains set and resolves to same node",
+			nodeName:         "vm1",
+			managedBy:        &managedBy,
+			attachedNodeName: "vm1",
+			expectedErr:      true,
+		},
+		{
+			desc:             "error when ManagedBy remains set and resolves to same node with different casing",
+			nodeName:         "VM1",
+			managedBy:        &managedBy,
+			attachedNodeName: "vm1",
+			expectedErr:      true,
+		},
+		{
+			desc:             "no error when ManagedBy resolves to different node",
+			nodeName:         "vm1",
+			managedBy:        &managedBy,
+			attachedNodeName: "vm2",
+			expectedErr:      false,
+		},
+		{
+			desc:               "error when ManagedBy remains set and instance cannot be resolved",
+			nodeName:           "vm1",
+			managedBy:          &managedBy,
+			getNodeNameByIDErr: cloudprovider.InstanceNotFound,
+			expectedErr:        true,
 		},
 	}
 
@@ -534,6 +562,9 @@ func TestCommonDetachDiskInstanceNotFoundWaitForDiskManagedByRemoved(t *testing.
 			mockVMSet := provider.NewMockVMSet(ctrl)
 			testCloud.VMSet = mockVMSet
 			mockVMSet.EXPECT().GetInstanceIDByNodeName(gomock.Any(), gomock.Any()).Return("", cloudprovider.InstanceNotFound).AnyTimes()
+			if test.managedBy != nil && test.getErr == nil {
+				mockVMSet.EXPECT().GetNodeNameByProviderID(gomock.Any(), *test.managedBy).Return(test.attachedNodeName, test.getNodeNameByIDErr).AnyTimes()
+			}
 
 			diskClient := mock_diskclient.NewMockInterface(ctrl)
 			testCloud.ComputeClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetDiskClientForSub(gomock.Any()).Return(diskClient, nil).AnyTimes()
@@ -548,7 +579,7 @@ func TestCommonDetachDiskInstanceNotFoundWaitForDiskManagedByRemoved(t *testing.
 			}
 			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name",
 				testCloud.SubscriptionID, testCloud.ResourceGroup)
-			err := common.DetachDisk(t.Context(), "disk-name", diskURI, "vm1")
+			err := common.DetachDisk(t.Context(), "disk-name", diskURI, test.nodeName)
 			assert.Equal(t, test.expectedErr, err != nil, "err: %v", err)
 		})
 	}
@@ -896,30 +927,55 @@ func TestGetValidCreationData(t *testing.T) {
 
 func TestIsInstanceNotFoundError(t *testing.T) {
 	testCases := []struct {
-		errMsg         string
+		desc           string
+		err            error
 		expectedResult bool
 	}{
 		{
-			errMsg:         "",
+			desc:           "empty error message",
+			err:            fmt.Errorf(""),
 			expectedResult: false,
 		},
 		{
-			errMsg:         "other error",
+			desc:           "unrelated error message",
+			err:            fmt.Errorf("other error"),
 			expectedResult: false,
 		},
 		{
-			errMsg:         "The provided instanceId 857 is not an active Virtual Machine Scale Set VM instanceId.",
+			desc:           "VMSS instance not active error message",
+			err:            fmt.Errorf("the provided instanceId 857 is not an active Virtual Machine Scale Set VM instanceId"),
 			expectedResult: true,
 		},
 		{
-			errMsg:         `compute.VirtualMachineScaleSetVMsClient#Update: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The provided instanceId 1181 is not an active Virtual Machine Scale Set VM instanceId." Target="instanceIds"`,
+			desc:           "VMSS instance not active error wrapped in request failure",
+			err:            fmt.Errorf(`compute.VirtualMachineScaleSetVMsClient#Update: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The provided instanceId 1181 is not an active Virtual Machine Scale Set VM instanceId." Target="instanceIds"`),
 			expectedResult: true,
+		},
+		{
+			desc: "Azure SDK ResponseError with 404 status code",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusNotFound,
+				RawResponse: &http.Response{
+					StatusCode: http.StatusNotFound,
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			desc: "Azure SDK ResponseError with non-404 status code",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusBadRequest,
+				RawResponse: &http.Response{
+					StatusCode: http.StatusBadRequest,
+				},
+			},
+			expectedResult: false,
 		},
 	}
 
 	for i, test := range testCases {
-		result := isInstanceNotFoundError(fmt.Errorf("%v", test.errMsg))
-		assert.Equal(t, test.expectedResult, result, "TestCase[%d]", i, result)
+		result := isInstanceNotFoundError(test.err)
+		assert.Equal(t, test.expectedResult, result, "TestCase[%d]: %s", i, test.desc)
 	}
 }
 


### PR DESCRIPTION
fix: incorrect node attached on waitingForDetached call

Cherry-pick changes from upstream to fix some cases where volumeattachement can't be properly GCed due to the driver wrongly assuming that the disk is still attached to the old node